### PR TITLE
Add ClawBench to agent evaluation benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ This is the reading list for the survey **"A Survey on the Optimization of Large
 37. Can LLM Already Serve as A Database Interface? A BIg Bench for Large-Scale Database Grounded Text-to-SQLs (NeurIPS 2023) [[paper](https://arxiv.org/abs/2305.03111)] [[code](https://github.com/AlibabaResearch/DAMO-ConvAI/tree/main/bird)]
 38. InterCode: Standardizing and Benchmarking Interactive Coding with Execution Feedback (NeurIPS 2023) [[paper](https://arxiv.org/abs/2306.14898)] [[code](https://github.com/princeton-nlp/intercode)]
 39. MLE-bench: Evaluating Machine Learning Agents on Machine Learning Engineering (**ICLR 2025**) [[paper](https://arxiv.org/abs/2410.07095)] [[code](https://github.com/openai/mle-bench)]
+40. ClawBench: Can AI Agents Complete Everyday Online Tasks? (**arXiv 2026**) [[paper](https://arxiv.org/abs/2604.08523)] [[code](https://github.com/TIGER-AI-Lab/ClawBench)]
 
 ### Multi-task Benchmarks
 


### PR DESCRIPTION
## What

Adds **ClawBench: Can AI Agents Complete Everyday Online Tasks?** to `Datasets and Benchmarks for Evaluation → General Evaluation Tasks`.

## Why it fits

ClawBench evaluates AI agents on 283 everyday tasks across live websites. It complements the section’s WebShop, WebArena, Mind2Web, and other interactive-agent benchmarks with production-site execution, isolated browser environments, and five-layer trajectory capture.

The entry follows the existing numbered format and links both the paper and open-source implementation.

Disclosure: I am a ClawBench maintainer submitting the benchmark for consideration.


Project links: [Website](https://claw-bench.com/) · [GitHub](https://github.com/reacher-z/ClawBench) · [Paper](https://arxiv.org/abs/2604.08523)